### PR TITLE
Persist option positions throughout the navigation

### DIFF
--- a/src/components/Question.vue
+++ b/src/components/Question.vue
@@ -23,12 +23,12 @@
 </template>
 
 <script>
-import _lodash from "lodash";
 import EventBus from "../event-bus";
 
 export default {
   props: {
     question: Object,
+    options: Array
   },
 
   data: () => ({
@@ -42,20 +42,6 @@ export default {
 
   destroyed() {
     EventBus.$off("question-changed");
-  },
-  computed: {
-    options() {
-      let options = {};
-      if (this.question) {
-        options = [
-          ...(this.question.incorrect_answers || []),
-          this.question.correct_answer,
-        ];
-        return _lodash.shuffle(options);
-      } else {
-        return options;
-      }
-    },
   },
   watch: {
     selectedOptionIndex: function (value) {

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -48,7 +48,7 @@ export default {
   created() {
     const self = this;
     EventBus.$on("selected-option", self.updateSelectedOption);
-
+    
     this.options = this.questions.map(question => _lodash.shuffle([...question.incorrect_answers, question.correct_answer]));
   },
   destroyed() {

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -1,5 +1,5 @@
 <template>
-  <Question :question="currentQuestion">
+  <Question :question="currentQuestion" :options="options[index]">
     <template v-slot:actions>
       <v-btn
         @click="previous"
@@ -30,6 +30,9 @@ import Question from "./Question";
 import Result from "./Result";
 import EventBus from "../event-bus";
 
+import _lodash from "lodash";
+
+
 export default {
   components: {
     Question,
@@ -39,12 +42,15 @@ export default {
     questions: Array,
   },
   data: () => ({
+    optionsArrays: [],
     answers: [],
     index: 0,
   }),
   created() {
     const self = this;
     EventBus.$on("selected-option", self.updateSelectedOption);
+
+    this.options = this.questions.map(question => _lodash.shuffle([...question.incorrect_answers, question.correct_answer]));
   },
   destroyed() {
     EventBus.$off("selected-option");
@@ -60,6 +66,7 @@ export default {
     next() {
       this.index++;
       this.navigator();
+      console.log(this.options);
     },
     previous() {
       this.index--;

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -32,7 +32,6 @@ import EventBus from "../event-bus";
 
 import _lodash from "lodash";
 
-
 export default {
   components: {
     Question,
@@ -42,7 +41,7 @@ export default {
     questions: Array,
   },
   data: () => ({
-    optionsArrays: [],
+    options: [],
     answers: [],
     index: 0,
   }),
@@ -66,7 +65,6 @@ export default {
     next() {
       this.index++;
       this.navigator();
-      console.log(this.options);
     },
     previous() {
       this.index--;


### PR DESCRIPTION
I opted for shuffling the options at the creation stage of the `Quiz` component. Since there's only ever 10 questions, this doesn't really impact loading times.